### PR TITLE
Support of database queries

### DIFF
--- a/config/bootstrap/queries.php
+++ b/config/bootstrap/queries.php
@@ -1,30 +1,45 @@
 <?php
-use \lithium\data\Connections;
 use li3_perf\extensions\util\Data;
 use lithium\action\Dispatcher;
+use lithium\data\Connections;
+use lithium\data\source\database\Result as DatabaseResult;
+// FIXME: remove this once a MySqlResult is a DatabaseResult
+use lithium\data\source\database\adapter\my_sql\Result as MySqlResult;
+use lithium\data\source\mongo_db\Result as MongoDBResult;
 
 Dispatcher::applyFilter('_callable', function($self, $params, $chain) {
-	
 	$filter_start = microtime(true);
-	Connections::get("default")->applyFilter("read", function($self, $params, $chain) use (&$MongoDb) { 
-		
+
+	Connections::get('default')->applyFilter('read', function($self, $params, $chain) {
+		$start = microtime(true);
 		$result = $chain->next($self, $params, $chain);
-		
+
 		if (method_exists($result, 'data')) {
-			
-			$query = array(
-				'time' => microtime(true),
-				'explain' => $result->result()->resource()->explain(),
-				'query' => $result->result()->resource()->info()
-			);
+			$db_result = $result->result();
+			$time = microtime(true);
+			$query = compact('time');
+
+			if ($db_result instanceof MongoDBResult) {
+				$query += array(
+					'explain' => $db_result->resource()->explain(),
+					'query' => $db_result->resource()->info()
+				);
+			} else if ($db_result instanceof DatabaseResult ||
+			           $db_result instanceof MySqlResult) {
+				$query += array(
+					'explain' => array('millis' => $time - $start),
+					'query' => $db_result->resource()->queryString
+				);
+			} else {
+				throw new \Exception('This kind of result is not supported.');
+			}
+
 			Data::append('queries', array($query));
-		
-			//	var_dump($params['query']->export($MongoDb) + array('result' => $result->data()));
 		}
-		
+
 		return $result;
 	});
-	
+
 	Data::append('timers', array('_filter_for_queries' => microtime(true) - $filter_start));
 	return $chain->next($self, $params, $chain);
 });


### PR DESCRIPTION
Hi,

I've started something to also support the queries made to databases. They are two problems:
- a `mysql\Result` isn't a `database\Result` (but @nateabele is on it I guess)
- without filtering `_execute` it cannot know about every SQL requests made, `read` being too high level.

it's also possible to run an `EXPLAIN …` for any `SELECT` requests made, but the results aren't very useful, so I dropped that idea.

Take this _pull request_ as a _review request_ open for comments. I'm thinking on doing more work on that branch before it could be properly merge (if you care about this).

Cheers,
