### PR TITLE
Avoid a strict standars message in PHP 5.3

### DIFF
--- a/config/bootstrap/dispatcher.php
+++ b/config/bootstrap/dispatcher.php
@@ -51,7 +51,8 @@ Dispatcher::applyFilter('run', function($self, $params, $chain) {
 	// Render the toolbar (unless it's an asset from the li3_perf library)
 	// Why? See li3_perf\extensions\util\Asset
 	$content_type = isset($result->headers['Content-Type']) ? $result->headers['Content-Type'] : '';
-	$content_type = array_shift(explode(';', $content_type, 2));
+	$content_type = explode(';', $content_type, 2);
+	$content_type = array_shift($content_type);
 	if(
 		!isset($params['request']->params['asset_type']) &&
 		(!$content_type || $content_type == 'text/html')


### PR DESCRIPTION
If you include in your error_reporting setting E_STRICT or E_ALL in PHP 5.3 or above you will get this message:
Strict Standards: Only variables should be passed by reference ...
This simple change will fix it
